### PR TITLE
Fix tests with sphinx >= 1.8 and resolve warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,26 @@
 language: python
-sudo: false
 git:
   depth: 1
 python:
-  - pypy-5.4.1
   - 2.7
   - 3.5
-# Pylint is not supported on 3.6 yet. See
-# https://github.com/PyCQA/pylint/issues/1113 et al.
-env:
-  matrix:
-    - ENV=latest
-    - ENV=oldest
+  - 3.6
+  - pypy
+  - pypy3
 matrix:
-# Only run the oldest environment once
-  exclude:
-    - python: 3.6
-      env: ENV=oldest
-    - python: pypy-5.4.1
-      env: ENV=oldest
+    include:
+        - python: "3.7"
+          dist: xenial
+
+
+before_install:
+  - python --version
+
+install:
+  - pip install -U pip setuptools
+  - pip install -U coverage coveralls pylint
+  - pip install -U -e .[test]
+
 script:
   - pylint -r no src/sphinxcontrib
   - coverage run setup.py test
@@ -27,14 +29,6 @@ after_success:
 notifications:
   email: false
 
-before_install:
-  - python --version
-
-install:
-  - pip install -U pip setuptools
-  - pip install -U coverage coveralls pylint
-  - if [[ $ENV == latest ]]; then pip install -U -e .[test]; fi
-  - if [[ $ENV == oldest ]]; then pip install Sphinx==1.3.5 && pip install -e .[test]; fi
 
 cache: pip
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,16 @@
-0.12 (unreleased)
+0.13 (unreleased)
 =================
 
-- Nothing changed yet.
+- Drop support for Sphinx < 1.7.
+
+- Fix tests on Sphinx >= 1.8.0.
+
+- Restore error message into the document by default from failed
+  program runs on Sphinx >= 1.8.0b1.
+
+- Fix deprecation warnings on Sphinx >= 1.8. Reported in `issue 29
+  <https://github.com/NextThought/sphinxcontrib-programoutput/issues/29>`_
+  by miili.
 
 
 0.11 (2017-05-18)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     name='sphinxcontrib-programoutput',
     version=read_version_number(),
     url='https://sphinxcontrib-programoutput.readthedocs.org/',
-    download_url='https://pypi.python.org/pypi/sphinxcontrib-programoutput',
+    download_url='https://pypi.org/project/sphinxcontrib-programoutput/',
     license='BSD',
     author='Sebastian Wiesner',
     author_email='lunaryorn@gmail.com',
@@ -69,6 +69,7 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         'Topic :: Documentation',
@@ -80,7 +81,7 @@ setup(
     namespace_packages=['sphinxcontrib'],
     include_package_data=True,
     install_requires=[
-        'Sphinx>=1.3.5',
+        'Sphinx>=1.7.0',
     ],
     tests_require=tests_require,
     extras_require={

--- a/src/sphinxcontrib/programoutput/tests/__init__.py
+++ b/src/sphinxcontrib/programoutput/tests/__init__.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 
 from docutils.parsers.rst import directives
+from docutils.parsers.rst import roles
 from sphinx.application import Sphinx
 
 from functools import update_wrapper
@@ -60,9 +61,12 @@ class AppMixin(object):
         # sphinxcontrib.programoutput: directive u'program-output' is
         # already registered, it will be overridden".
         self.directives = directives._directives.copy()
+        # Likewise for 'eq'
+        self.roles = roles._roles.copy()
 
     def tearDown(self):
         directives._directives = self.directives
+        roles._roles = self.roles
 
     @Lazy
     def tmpdir(self):

--- a/src/sphinxcontrib/programoutput/tests/__init__.py
+++ b/src/sphinxcontrib/programoutput/tests/__init__.py
@@ -10,6 +10,8 @@ from sphinx.application import Sphinx
 from functools import update_wrapper
 
 # pylint:disable=no-self-use,protected-access,too-few-public-methods
+# useless-object-inheritance is version specific
+# pylint:disable=bad-option-value,useless-object-inheritance
 
 class Lazy(object):
 

--- a/src/sphinxcontrib/programoutput/tests/test_directive.py
+++ b/src/sphinxcontrib/programoutput/tests/test_directive.py
@@ -295,7 +295,7 @@ spam with eggs""")
     def test_non_existing_executable(self):
         # check that a proper error message appears in the document
         message = self.doctree.next_node(system_message)
-        assert message
+        self.assertTrue(message)
         srcfile = os.path.join(self.srcdir, 'content', 'doc.rst')
         self.assertEqual(message['source'], srcfile)
         self.assertEqual(message['line'], 5)
@@ -314,7 +314,7 @@ spam with eggs""")
         doctree = self.doctree
         srcdir = self.srcdir
         message = doctree.next_node(system_message)
-        assert message
+        self.assertTrue(message)
         srcfile = os.path.join(srcdir, 'content', 'doc.rst')
         self.assertEqual(message['source'], srcfile)
         self.assertEqual(message['line'], 5)

--- a/src/sphinxcontrib/programoutput/tests/test_setup.py
+++ b/src/sphinxcontrib/programoutput/tests/test_setup.py
@@ -36,8 +36,8 @@ class TestSetup(AppMixin,
 
     def test_init_cache(self):
         app = self.app
-        assert isinstance(app.env.programoutput_cache, ProgramOutputCache)
-        assert not app.env.programoutput_cache
+        self.assertIsInstance(app.env.programoutput_cache, ProgramOutputCache)
+        self.assertFalse(app.env.programoutput_cache)
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py27old,py36,pypy,doc
+envlist=py27,py27old,py36,py37,pypy,doc
 
 [testenv]
 deps =
@@ -9,7 +9,7 @@ commands=
 
 [testenv:py27old]
 deps =
-    Sphinx == 1.3.5
+    Sphinx == 1.7.0
 
 [testenv:doc]
 deps =


### PR DESCRIPTION
Requires sphinx 1.7 or newer.

Fixes #29 and fixes #30.

Add Python 3.7.