### PR TITLE
Cannot handle Unicode characters with Python 2.7

### DIFF
--- a/src/sphinxcontrib/programoutput/__init__.py
+++ b/src/sphinxcontrib/programoutput/__init__.py
@@ -264,7 +264,7 @@ def init_cache(app):
 
 def setup(app):
     app.add_config_value('programoutput_prompt_template',
-                         '$ {command}\n{output}', 'env')
+                         u'$ {command}\n{output}', 'env')
     app.add_directive('program-output', ProgramOutputDirective)
     app.add_directive('command-output', ProgramOutputDirective)
     app.connect('builder-inited', init_cache)

--- a/src/sphinxcontrib/programoutput/tests/__init__.py
+++ b/src/sphinxcontrib/programoutput/tests/__init__.py
@@ -1,3 +1,4 @@
+import codecs
 import os
 import os.path
 import shutil
@@ -96,7 +97,7 @@ class AppMixin(object):
         content_directory = os.path.join(srcdir, 'content')
         os.mkdir(content_directory)
         content_document = os.path.join(content_directory, 'doc.rst')
-        with open(content_document, 'w') as f:
+        with codecs.open(content_document, encoding='utf-8', mode='w') as f:
             f.write("=====\n")
             f.write("Title\n")
             f.write("=====\n\n")

--- a/src/sphinxcontrib/programoutput/tests/test_directive.py
+++ b/src/sphinxcontrib/programoutput/tests/test_directive.py
@@ -189,6 +189,14 @@ spam with eggs""")
         self.assert_cache(self.app, 'echo spam with eggs', 'spam with eggs')
 
 
+    @with_content(u'.. command-output:: echo "U+2264 ≤ LESS-THAN OR EQUAL TO"')
+    def test_prompt_with_utf8(self):
+        self.assert_output(self.doctree, u"""\
+$ echo "U+2264 ≤ LESS-THAN OR EQUAL TO"
+U+2264 ≤ LESS-THAN OR EQUAL TO""")
+        self.assert_cache(self.app, u'echo "U+2264 ≤ LESS-THAN OR EQUAL TO"', u'U+2264 ≤ LESS-THAN OR EQUAL TO')
+
+
     @with_content('''\
     .. program-output:: echo
        :shell:


### PR DESCRIPTION
The following snippet fails with an UnicodeEncodeError on Python 2.7:
```
.. command-output:: echo "U+2264 ≤ LESS-THAN OR EQUAL TO"
```
The error is
```
  File ".../sphinxcontrib-programoutput/src/sphinxcontrib/programoutput/__init__.py", line 245, in run_programs
    returncode=returncode)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2264' in position 13: ordinal not in range(128)
```

The internet(tm) suggested that when using `pattern.format(str)` both `str` and `pattern` have to have the same encoding. In the above example `pattern` is ASCII where as `str` is the above UTF-8 string. The solution is to make them both UTF-8.

Python 3 does not seem to have this problem (probably due to the unicode change of str in Python 3).

**Workaround**:
Add
```
programoutput_prompt_template = u'$ {command}\n{output}'
```
to your Sphinx `conf.py` (Note the `u` infront of the string which marks it as UTF-8).

**The commits**
Attached three commits
* one which adds a test for Unicode (letting even the test suite itself fail on Python 2.7, see 3rd commit)
* one which applies the workaround above
* the last one is a commit to make the test suite handle Unicode strings (otherwise it fails on `f.write()` in `sphinxcontrib-programoutput/src/sphinxcontrib/programoutput/tests/__init__.py`, line 99). However, this triggers `DeprecationWarning: 'U' mode is deprecated` on Python 3.6 (and maybe other 3.x).

Feel free to use them as you wish.