### PR TITLE
More careful handling of the output in regards to what should be unicode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@
 
 - Add support for Sphinx 2.0 on Python 3.
 
+- Avoid unicode errors when the program command or output produced
+  non-ASCII output and the configured prompt was a byte string. This
+  was most likely under Python 2, where the default configured prompt
+  is a byte string. Reported by, and patch inspired by, `issue 33
+  <https://github.com/NextThought/sphinxcontrib-programoutput/issues/33>`_
+  by latricewilgus.
+
 0.13 (2018-12-22)
 =================
 

--- a/src/sphinxcontrib/programoutput/tests/__init__.py
+++ b/src/sphinxcontrib/programoutput/tests/__init__.py
@@ -76,7 +76,16 @@ def _find_duplicate_default_nodes():
 
 class AppMixin(object):
 
+    #: The contents of the main 'doc.rst' document.
+    #:
+    #: This will be written as a bytestring to the document, allowing for
+    #: the document to be in an arbitrary encoding.
+    #:
+    #: If this object is not a bytestring, it will first be encoded using
+    #: the encoding named in `self.document_encoding`.
     document_content = '=============\ndummy content\n=============\n'
+
+    document_encoding = 'utf-8'
 
     duplicate_nodes_to_remove = _find_duplicate_default_nodes()
 
@@ -125,11 +134,16 @@ class AppMixin(object):
         content_directory = os.path.join(srcdir, 'content')
         os.mkdir(content_directory)
         content_document = os.path.join(content_directory, 'doc.rst')
-        with open(content_document, 'w') as f:
-            f.write("=====\n")
-            f.write("Title\n")
-            f.write("=====\n\n")
-            f.write(self.document_content)
+        contents = self.document_content
+        if not isinstance(contents, bytes):
+            contents = contents.encode(self.document_encoding)
+
+        with open(content_document, 'wb') as f:
+            f.write(b"=====\n")
+            f.write(b"Title\n")
+            f.write(b"=====\n\n")
+
+            f.write(contents)
 
         return srcdir
 

--- a/src/sphinxcontrib/programoutput/tests/test_directive.py
+++ b/src/sphinxcontrib/programoutput/tests/test_directive.py
@@ -267,8 +267,6 @@ spam with eggs""")
         self.assertIn("python -c 'import sys; sys.exit(1)'",
                       excinfo.exception.args[0])
 
-
-
     @with_content("""\
     .. program-output:: python -c 'import sys; print("foo"); sys.exit(1)'
        :returncode: 1""")
@@ -276,7 +274,6 @@ spam with eggs""")
         self.assert_output(self.doctree, 'foo')
         self.assert_cache(self.app, 'python -c \'import sys; print("foo"); sys.exit(1)\'',
                           'foo', returncode=1)
-
 
     @with_content("""\
 .. command-output:: python -c 'import sys; sys.exit(1)'
@@ -292,7 +289,6 @@ spam with eggs""")
         self.assert_cache(app, "python -c 'import sys; sys.exit(1)'", '',
                           returncode=1)
 
-
     @with_content(u".. program-output:: 'spam with eggs'", ignore_warnings=True)
     def test_non_existing_executable(self):
         # check that a proper error message appears in the document
@@ -306,7 +302,6 @@ spam with eggs""")
         self.assertIn(srcfile, message_text)
         self.assertIn('spam with eggs', message_text)
         self.assertIn("Errno", message_text)
-
 
     @with_content("""\
     .. program-output:: echo spam
@@ -325,6 +320,45 @@ spam with eggs""")
         self.assertIn(srcfile, message_text)
         self.assertIn('subdir', message_text)
         self.assertIn("No such file or directory", message_text)
+
+    @with_content(u'.. command-output:: echo "U+2264 ≤ LESS-THAN OR EQUAL TO"')
+    def test_default_prompt_with_unicode_output(self):
+        self.assert_output(
+            self.doctree, u"""\
+$ echo "U+2264 ≤ LESS-THAN OR EQUAL TO"
+U+2264 ≤ LESS-THAN OR EQUAL TO""")
+        self.assert_cache(
+            self.app,
+            u'echo "U+2264 ≤ LESS-THAN OR EQUAL TO"',
+            u'U+2264 ≤ LESS-THAN OR EQUAL TO')
+
+    @with_content(u'.. command-output:: echo "U+2264 ≤ LESS-THAN OR EQUAL TO"',
+                  programoutput_prompt_template=b'> {command}\n{output}')
+    def test_bytes_prompt_with_unicode_output(self):
+        self.assert_output(
+            self.doctree, u"""\
+> echo "U+2264 ≤ LESS-THAN OR EQUAL TO"
+U+2264 ≤ LESS-THAN OR EQUAL TO""")
+        self.assert_cache(
+            self.app,
+            u'echo "U+2264 ≤ LESS-THAN OR EQUAL TO"',
+            u'U+2264 ≤ LESS-THAN OR EQUAL TO')
+
+    @with_content("""\
+    .. program-output:: echo -e "U+2264 ≤ LESS-THAN OR EQUAL TO\\n≤ line2\\n≤ line3"
+        :ellipsis: 2
+    """)
+    def test_unicode_output_with_ellipsis(self):
+        self.assert_output(
+            self.doctree, u"""\
+U+2264 \u2264 LESS-THAN OR EQUAL TO\n\u2264 line2\n..."""
+        )
+        self.assert_cache(
+            self.app,
+            u'echo -e "U+2264 ≤ LESS-THAN OR EQUAL TO\\n≤ line2\\n≤ line3"',
+            u'U+2264 \u2264 LESS-THAN OR EQUAL TO\n\u2264 line2\n\u2264 line3'
+        )
+
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
Ensure the prompt string is always unicode.

Fixes #32 and fixes #33