### PR TITLE
Use sys.executable instead of a hardcoded python.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,15 @@
 group: travis_latest
 language: python
+group: travis_latest
 git:
   depth: 1
 python:
   - 2.7
   - 3.5
   - 3.6
+  - 3.7
   - pypy
   - pypy3
-# As of Apr 2019, we can't use Python 3.7 at the top-level
-# without using 'dist: xenial' at the top level. But that
-# breaks PyPy and PyPy3 (they can't be installed)
-matrix:
-  include:
-    - python: "3.7"
-      dist: xenial
 
 env:
   global:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,12 @@
 0.15 (unreleased)
 =================
 
-- Nothing changed yet.
+- Make the test suite stop assuming the presence of a 'python'
+  executable on the path. Instead it uses ``sys.executable`` (which
+  shouldn't have spaces). Note that it does continue to assume the
+  presence of other executables, such as 'echo'. Reported in `issue 38
+  <https://github.com/NextThought/sphinxcontrib-programoutput/issues/38>`_
+  by John Vandenberg.
 
 
 0.14 (2019-04-08)

--- a/src/sphinxcontrib/programoutput/tests/__init__.py
+++ b/src/sphinxcontrib/programoutput/tests/__init__.py
@@ -194,17 +194,3 @@ class AppMixin(object):
         return app.env.get_doctree('content/doc')
 
 assert isinstance(AppMixin.app, Lazy) # coverage
-
-def with_content(content, **kwargs):
-    def factory(f):
-        def w(self):
-            self.document_content = content
-            if kwargs:
-                if 'ignore_warnings' in kwargs:
-                    getattr(self, 'ignore_warnings')
-                    self.ignore_warnings = kwargs.pop("ignore_warnings")
-                getattr(self, 'confoverrides')
-                self.confoverrides = kwargs
-            f(self)
-        return w
-    return factory

--- a/src/sphinxcontrib/programoutput/tests/test_cache.py
+++ b/src/sphinxcontrib/programoutput/tests/test_cache.py
@@ -27,6 +27,7 @@ from __future__ import print_function, division, absolute_import
 
 import os
 import pickle
+import sys
 import unittest
 
 from sphinxcontrib.programoutput import ProgramOutputCache, Command
@@ -58,7 +59,7 @@ class TestCache(AppMixin,
         cwd = os.path.join(self.tmpdir, 'wd')
         os.mkdir(cwd)
         cwd = os.path.realpath(os.path.normpath(str(cwd)))
-        cmd = ['python', '-c', 'import sys, os; sys.stdout.write(os.getcwd())']
+        cmd = [sys.executable, '-c', 'import sys, os; sys.stdout.write(os.getcwd())']
         self.assert_cache(cache, Command(cmd, working_directory=cwd), cwd)
 
 
@@ -73,19 +74,19 @@ class TestCache(AppMixin,
 
     def test_hidden_standard_error(self):
         cache = ProgramOutputCache()
-        cmd = ['python', '-c', 'import sys; sys.stderr.write("spam")']
+        cmd = [sys.executable, '-c', 'import sys; sys.stderr.write("spam")']
         self.assert_cache(cache, Command(cmd, hide_standard_error=True), '')
 
 
     def test_nonzero_return_code(self):
         cache = ProgramOutputCache()
-        cmd = ['python', '-c', 'import sys; sys.exit(1)']
+        cmd = [sys.executable, '-c', 'import sys; sys.exit(1)']
         self.assert_cache(cache, Command(cmd), '', returncode=1)
 
 
     def test_nonzero_return_code_shell(self):
         cache = ProgramOutputCache()
-        cmd = "python -c 'import sys; sys.exit(1)'"
+        cmd = sys.executable + " -c 'import sys; sys.exit(1)'"
         self.assert_cache(cache, Command(cmd, shell=True), '', returncode=1)
 
     def test_cache_pickled(self):

--- a/src/sphinxcontrib/programoutput/tests/test_command.py
+++ b/src/sphinxcontrib/programoutput/tests/test_command.py
@@ -25,6 +25,7 @@
 
 from __future__ import print_function, division, absolute_import
 
+import sys
 import unittest
 import tempfile
 import shutil
@@ -108,14 +109,14 @@ class TestCommand(unittest.TestCase):
 
     def test_get_output_non_zero(self):
         returncode, output = Command(
-            'python -c "import sys; print(\'spam\'); sys.exit(1)"').get_output()
+            sys.executable + ' -c "import sys; print(\'spam\'); sys.exit(1)"').get_output()
         self.assertEqual(returncode, 1)
         self.assertEqual(output, 'spam')
 
 
     def test_get_output_with_hidden_standard_error(self):
         returncode, output = Command(
-            'python -c "import sys; sys.stderr.write(\'spam\')"',
+            sys.executable + ' -c "import sys; sys.stderr.write(\'spam\')"',
             hide_standard_error=True).get_output()
         self.assertEqual(returncode, 0)
         self.assertEqual(output, '')
@@ -125,7 +126,7 @@ class TestCommand(unittest.TestCase):
         tmpdir = tempfile.mkdtemp()
         cwd = os.path.realpath(str(tmpdir))
         returncode, output = Command(
-            'python -c "import sys, os; sys.stdout.write(os.getcwd())"',
+            sys.executable + ' -c "import sys, os; sys.stdout.write(os.getcwd())"',
             working_directory=cwd).get_output()
         self.assertEqual(returncode, 0)
         self.assertEqual(output, cwd)


### PR DESCRIPTION
Fixes #38.