### PR TITLE
Add caption and name options to output blocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,7 @@
 0.16 (unreleased)
 =================
 
-- Nothing changed yet.
-
+- Added ``name`` and ``caption`` options.
 
 0.15 (2019-09-16)
 =================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -213,6 +213,12 @@ Reference
    build warning is issued.  The expected return code defaults to 0, and can be
    changed with the ``returncode`` option.
 
+   A ``caption`` option can be given to show the given name, or by default the
+   given command, before the output block.
+   A ``name`` option with a target name can be provided to reference the
+   command block by using ``ref``.
+
+
 .. directive:: command-output
 
    Same as :dir:`program-output`, but with enabled ``prompt`` option.

--- a/src/sphinxcontrib/programoutput/__init__.py
+++ b/src/sphinxcontrib/programoutput/__init__.py
@@ -46,7 +46,6 @@ from docutils.parsers import rst
 from docutils.parsers.rst.directives import flag, unchanged, nonnegative_int
 from docutils.statemachine import StringList
 
-from sphinx.locale import __
 from sphinx.util import logging as sphinx_logging
 
 __version__ = '0.16.dev0'
@@ -57,24 +56,23 @@ class program_output(nodes.Element):
     pass
 
 
-def container_wrapper(directive, literal_node, caption):
+def _container_wrapper(directive, literal_node, caption):
     container_node = nodes.container('', literal_block=True,
                                      classes=['literal-block-wrapper'])
     parsed = nodes.Element()
     directive.state.nested_parse(StringList([caption], source=''),
                                  directive.content_offset, parsed)
     if isinstance(parsed[0], nodes.system_message):
-        msg = __('Invalid caption: %s' % parsed[0].astext())
+        msg = 'Invalid caption: %s' % parsed[0].astext()
         raise ValueError(msg)
-    if isinstance(parsed[0], nodes.Element):
-        caption_node = nodes.caption(parsed[0].rawsource, '',
-                                     *parsed[0].children)
-        caption_node.source = literal_node.source
-        caption_node.line = literal_node.line
-        container_node += caption_node
-        container_node += literal_node
-        return container_node
-    raise RuntimeError  # never reached
+    assert isinstance(parsed[0], nodes.Element)
+    caption_node = nodes.caption(parsed[0].rawsource, '',
+                                 *parsed[0].children)
+    caption_node.source = literal_node.source
+    caption_node.line = literal_node.line
+    container_node += caption_node
+    container_node += literal_node
+    return container_node
 
 
 def _slice(value):
@@ -116,7 +114,7 @@ class ProgramOutputDirective(rst.Directive):
             node['strip_lines'] = self.options['ellipsis']
         if 'caption' in self.options:
             caption = self.options['caption'] or self.arguments[0]
-            node = container_wrapper(self, node, caption)
+            node = _container_wrapper(self, node, caption)
 
         self.add_name(node)
         return [node]

--- a/src/sphinxcontrib/programoutput/__init__.py
+++ b/src/sphinxcontrib/programoutput/__init__.py
@@ -62,7 +62,9 @@ def _container_wrapper(directive, literal_node, caption):
     parsed = nodes.Element()
     directive.state.nested_parse(StringList([caption], source=''),
                                  directive.content_offset, parsed)
-    if isinstance(parsed[0], nodes.system_message):
+    if isinstance(parsed[0], nodes.system_message): # pragma: no cover
+        # TODO: Figure out if this is really possible and how to produce
+        # it in a test case.
         msg = 'Invalid caption: %s' % parsed[0].astext()
         raise ValueError(msg)
     assert isinstance(parsed[0], nodes.Element)

--- a/src/sphinxcontrib/programoutput/__init__.py
+++ b/src/sphinxcontrib/programoutput/__init__.py
@@ -92,7 +92,7 @@ class ProgramOutputDirective(rst.Directive):
     option_spec = dict(shell=flag, prompt=flag, nostderr=flag,
                        ellipsis=_slice, extraargs=unchanged,
                        returncode=nonnegative_int, cwd=unchanged,
-                       caption=unchanged)
+                       caption=unchanged, name=unchanged)
 
     def run(self):
         env = self.state.document.settings.env
@@ -117,6 +117,8 @@ class ProgramOutputDirective(rst.Directive):
         if 'caption' in self.options:
             caption = self.options['caption'] or self.arguments[0]
             node = container_wrapper(self, node, caption)
+
+        self.add_name(node)
         return [node]
 
 

--- a/src/sphinxcontrib/programoutput/__init__.py
+++ b/src/sphinxcontrib/programoutput/__init__.py
@@ -44,7 +44,9 @@ from collections import defaultdict, namedtuple
 from docutils import nodes
 from docutils.parsers import rst
 from docutils.parsers.rst.directives import flag, unchanged, nonnegative_int
+from docutils.statemachine import StringList
 
+from sphinx.locale import __
 from sphinx.util import logging as sphinx_logging
 
 __version__ = '0.16.dev0'
@@ -53,6 +55,26 @@ logger = sphinx_logging.getLogger('contrib.programoutput')
 
 class program_output(nodes.Element):
     pass
+
+
+def container_wrapper(directive, literal_node, caption):
+    container_node = nodes.container('', literal_block=True,
+                                     classes=['literal-block-wrapper'])
+    parsed = nodes.Element()
+    directive.state.nested_parse(StringList([caption], source=''),
+                                 directive.content_offset, parsed)
+    if isinstance(parsed[0], nodes.system_message):
+        msg = __('Invalid caption: %s' % parsed[0].astext())
+        raise ValueError(msg)
+    if isinstance(parsed[0], nodes.Element):
+        caption_node = nodes.caption(parsed[0].rawsource, '',
+                                     *parsed[0].children)
+        caption_node.source = literal_node.source
+        caption_node.line = literal_node.line
+        container_node += caption_node
+        container_node += literal_node
+        return container_node
+    raise RuntimeError  # never reached
 
 
 def _slice(value):
@@ -69,7 +91,8 @@ class ProgramOutputDirective(rst.Directive):
 
     option_spec = dict(shell=flag, prompt=flag, nostderr=flag,
                        ellipsis=_slice, extraargs=unchanged,
-                       returncode=nonnegative_int, cwd=unchanged)
+                       returncode=nonnegative_int, cwd=unchanged,
+                       caption=unchanged)
 
     def run(self):
         env = self.state.document.settings.env
@@ -91,6 +114,9 @@ class ProgramOutputDirective(rst.Directive):
         node['returncode'] = self.options.get('returncode', 0)
         if 'ellipsis' in self.options:
             node['strip_lines'] = self.options['ellipsis']
+        if 'caption' in self.options:
+            caption = self.options['caption'] or self.arguments[0]
+            node = container_wrapper(self, node, caption)
         return [node]
 
 

--- a/src/sphinxcontrib/programoutput/tests/test_directive.py
+++ b/src/sphinxcontrib/programoutput/tests/test_directive.py
@@ -31,7 +31,7 @@ import sys
 import unittest
 
 from sphinx.errors import SphinxWarning
-from docutils.nodes import literal_block, system_message
+from docutils.nodes import caption, container, literal_block, system_message
 
 from sphinxcontrib.programoutput import Command
 
@@ -66,11 +66,24 @@ def with_content(content, **kwargs):
 class TestDirective(AppMixin,
                     unittest.TestCase):
 
-    def assert_output(self, doctree, output):
+    def assert_output(self, doctree, output, **kwargs):
         __tracebackhide__ = True
         literal = doctree.next_node(literal_block)
         self.assertTrue(literal)
         self.assertEqual(literal.astext(), output)
+
+        if 'caption' in kwargs:
+            caption_node = doctree.next_node(caption)
+            self.assertTrue(caption_node)
+            self.assertEqual(caption_node.astext(), kwargs.get('caption'))
+
+        if 'name' in kwargs:
+            if 'caption' in kwargs:
+                container_node = doctree.next_node(container)
+                self.assertTrue(container_node)
+                self.assertIn(kwargs.get('name'), container_node.get('ids'))
+            else:
+                self.assertIn(kwargs.get('name'), literal.get('ids'))
 
     def assert_cache(self, app, cmd, output, use_shell=False,
                      hide_standard_error=False, returncode=0,
@@ -388,6 +401,34 @@ U+2264 \u2264 LESS-THAN OR EQUAL TO\n\u2264 line2\n..."""
             u'U+2264 \u2264 LESS-THAN OR EQUAL TO\n\u2264 line2\n\u2264 line3'
         )
 
+    @with_content("""\
+    .. program-output:: echo spam
+       :caption:""")
+    def test_caption_default(self):
+        self.assert_output(self.doctree, 'spam', caption='echo spam')
+        self.assert_cache(self.app, 'echo spam', 'spam')
+
+    @with_content("""\
+    .. program-output:: echo spam
+       :caption: mycaption""")
+    def test_caption(self):
+        self.assert_output(self.doctree, 'spam', caption='mycaption')
+        self.assert_cache(self.app, 'echo spam', 'spam')
+
+    @with_content("""\
+    .. program-output:: echo spam
+       :name: myname""")
+    def test_name(self):
+        self.assert_output(self.doctree, 'spam', name='myname')
+        self.assert_cache(self.app, 'echo spam', 'spam')
+
+    @with_content("""\
+    .. program-output:: echo spam
+       :caption: mycaption
+       :name: myname""")
+    def test_name_with_caption(self):
+        self.assert_output(self.doctree, 'spam', caption='mycaption', name='myname')
+        self.assert_cache(self.app, 'echo spam', 'spam')
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/sphinxcontrib/programoutput/tests/test_directive.py
+++ b/src/sphinxcontrib/programoutput/tests/test_directive.py
@@ -430,6 +430,7 @@ U+2264 \u2264 LESS-THAN OR EQUAL TO\n\u2264 line2\n..."""
         self.assert_output(self.doctree, 'spam', caption='mycaption', name='myname')
         self.assert_cache(self.app, 'echo spam', 'spam')
 
+
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py27-old,py36,py37,py38,pypy,doc
+envlist=py27,py27-old,py36,py37,py38,pypy,doc,coverage
 
 [testenv]
 usedevelop = true
@@ -7,12 +7,20 @@ extras =
     test
 deps =
     pylint
+    coverage
     old: Sphinx == 1.7.0
 commands =
-    python -m unittest discover -s src
+    coverage run -p -m unittest discover -s src
     pylint -r no src/sphinxcontrib
 passenv = HOME
 
+[testenv:coverage]
+commands =
+    coverage combine
+    coverage html -i
+    coverage report -i --fail-under=100
+depends = py27, py27-old, py36, py37, py38, pypy
+parallel_show_output = true
 
 [testenv:doc]
 commands =


### PR DESCRIPTION
I would like to be able to caption and reference `program-output` and `command-output` block like `literalinclude` directives.

As such, this PR is heavily inspired from what is already done for `literalinclude`.
It adds the `:name:` option to be able to reference the output block from elsewhere, and the `:caption:` option to set a caption to the output block.

Thanks in advance for looking at it.