### PR TITLE
Expose command output on errors

### DIFF
--- a/src/sphinxcontrib/programoutput/__init__.py
+++ b/src/sphinxcontrib/programoutput/__init__.py
@@ -270,8 +270,8 @@ def run_programs(app, doctree):
         else:
             if returncode != node['returncode']:
                 logger.warning(
-                    'Unexpected return code %s from command %s',
-                    returncode, command
+                    'Unexpected return code %s from command %s\n%s',
+                    returncode, command, output
                 )
 
             # replace lines with ..., if ellipsis is specified


### PR DESCRIPTION
This includes the output of the failed command, which would make
debugging much easier, especially on CI/CD systems.

Partial-Fix: #50